### PR TITLE
Add adjusted-cosine and Jaccard distance metrics to kNN recommender

### DIFF
--- a/doc/training.rst
+++ b/doc/training.rst
@@ -70,8 +70,8 @@ For a SLIM recommender you probably want to specify::
 
 For a k-nearest neighbour recommender you just need to supply::
 
-      --metric=METRIC       metric for knn recommender: cosine | dot (default:
-                        cosine)
+      --metric=METRIC       metric for knn recommender: cosine | dot |
+                            adjusted_cosine | jaccard (default: cosine)
 
 In this case ``max_sims`` is simply passed to the constructor
 of the ``KNNRecommender`` as the value of ``k``.

--- a/mrec/examples/train.py
+++ b/mrec/examples/train.py
@@ -23,7 +23,8 @@ def main():
 
     from mrec import load_fast_sparse_matrix, save_recommender
     from mrec.item_similarity.slim import SLIM
-    from mrec.item_similarity.knn import CosineKNNRecommender, DotProductKNNRecommender
+    from mrec.item_similarity.knn import (CosineKNNRecommender, DotProductKNNRecommender,
+                                          AdjustedCosineKNNRecommender, JaccardKNNRecommender)
     from mrec.mf.wrmf import WRMFRecommender
     from mrec.mf.warp import WARPMFRecommender
     from mrec.mf.warp2 import WARP2MFRecommender
@@ -45,7 +46,7 @@ def main():
     parser.add_option('--learner',dest='learner',default='sgd',help='underlying learner for SLIM learner: sgd | elasticnet | fs_sgd (default: %default)')
     parser.add_option('--l1_reg',dest='l1_reg',type='float',default=0.001,help='l1 regularization constant (default: %default)')
     parser.add_option('--l2_reg',dest='l2_reg',type='float',default=0.0001,help='l2 regularization constant (default: %default)')
-    parser.add_option('--metric',dest='metric',default='cosine',help='metric for knn recommender: cosine | dot (default: %default)')
+    parser.add_option('--metric',dest='metric',default='cosine',help='metric for knn recommender: cosine | dot | adjusted_cosine | jaccard (default: %default)')
     parser.add_option('--num_factors',dest='num_factors',type='int',default=80,help='number of latent factors (default: %default)')
     parser.add_option('--alpha',dest='alpha',type='float',default=1.0,help='wrmf confidence constant (default: %default)')
     parser.add_option('--lbda',dest='lbda',type='float',default=0.015,help='wrmf regularization constant (default: %default)')
@@ -103,6 +104,10 @@ def main():
             model = CosineKNNRecommender(k=opts.max_sims)
         elif opts.metric == 'dot':
             model = DotProductKNNRecommender(k=opts.max_sims)
+        elif opts.metric == 'adjusted_cosine':
+            model = AdjustedCosineKNNRecommender(k=opts.max_sims)
+        elif opts.metric == 'jaccard':
+            model = JaccardKNNRecommender(k=opts.max_sims)
         else:
             parser.print_help()
             raise SystemExit('unknown metric: {0}'.format(opts.metric))

--- a/mrec/item_similarity/knn.py
+++ b/mrec/item_similarity/knn.py
@@ -142,9 +142,13 @@ class JaccardKNNRecommender(KNNRecommender):
 
         for idx, row in enumerate(self._cached_bool):
             union = (row + ba).sum()
-            count = bsum + row.sum()
-            intersection = count-union
-            sims.append(float(intersection) / union)
+            # if, somehow, we have two empty vectors...
+            if union == 0:
+                sims.append(0)
+            else:
+                count = bsum + row.sum()
+                intersection = count-union
+                sims.append(float(intersection) / union)
         return np.asarray(sims)
 
     def __str__(self):

--- a/mrec/item_similarity/knn.py
+++ b/mrec/item_similarity/knn.py
@@ -4,7 +4,10 @@ intended to provide evaluation baselines.
 """
 
 import numpy as np
+import scipy.sparse
 from sklearn.metrics.pairwise import cosine_similarity
+from sklearn.utils.extmath import safe_sparse_dot
+
 from recommender import ItemSimilarityRecommender
 
 class KNNRecommender(ItemSimilarityRecommender):
@@ -73,6 +76,79 @@ class CosineKNNRecommender(KNNRecommender):
 
     def __str__(self):
         return 'CosineKNNRecommender(k={0})'.format(self.k)
+
+class AdjustedCosineKNNRecommender(KNNRecommender):
+    """
+    Similarity between two items is the adjusted cosine similarity:
+    this is the cosine similarity between mean-centered vectors over the
+    subset of users who have rated both items.
+
+    See Sarwar et al, 'Item-Based Collaborative Filtering Recommendation Algorithms' (WWW '10).
+    """
+
+
+    def compute_all_similarities(self, A, a):
+
+        # have we been training using this recommender before?
+        _cached_deltas = getattr(self, '_cached_deltas', None)
+
+        if _cached_deltas is None:
+            # First, we need to normalize ratings in A --
+            # divide through the set ratings by the mean rating of rated items.
+            #
+            # First, we need the mean - the sum over the count.
+            #
+            mean = A.sum(axis=1) / A.astype(bool).sum(axis=1).astype(float)
+            #
+            # we now want a sparse matrix where zero elements in the original matrix
+            # are still zero, and non-zero elements are equal to the user mean.
+            # we can get this by multiplying a diagonal matrix (as mean) against a
+            # binarized version of the original matrix
+            #
+            # Why the diagonal matrix? Because this is a sparse matrix, normal broadcasting rules
+            # don't apply, so we have to do the matrix multiplication explicitly.
+            #
+            dim = max(mean.shape)
+            diag = scipy.sparse.lil_matrix((dim, dim))
+            diag.setdiag(np.asarray(mean.flatten())[0])
+            delta_A = diag * A.astype(bool).astype(float)
+            self._cached_deltas = delta_A
+
+        # now, finally, we can get the mean-centered values:
+        norm_A = A - self._cached_deltas
+        return cosine_similarity(norm_A.T, a.T).flatten()
+
+    def __str__(self):
+        return 'AdjustedCosineKNNRecommender(k={0})'.format(self.k)
+
+class JaccardKNNRecommender(KNNRecommender):
+    """
+    Similarity between two items is the Jaccard similarity (intersection/union) between
+    vectors of booleans, binarized as (zero, greater_than_zero).
+
+    This is fiercely slow. In production, you likely don't want to be using this.
+    """
+    def compute_all_similarities(self,A,a):
+        _cached_bool = getattr(self, '_cached_bool', None)
+        _counts = getattr(self, '_counts', None)
+
+        if _cached_bool == None:
+            _cached_bool = A.astype(bool).T
+            self._cached_bool = _cached_bool
+
+        sims = []
+        ba = a.astype(bool).T
+        bsum = ba.sum()
+
+        for idx, row in enumerate(self._cached_bool):
+            union = (row + ba).sum()
+            count = bsum + row.sum()
+            intersection = count-union
+            sims.append(float(intersection) / union)
+        return np.asarray(sims)
+
+    def __str__(self):
+        return 'JaccardKNNRecommender(k={0})'.format(self.k)
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
Hi there,

Thanks for writing mrec! I'm using it here at Flipboard to baseline some potential recommenders. In doing that, I needed to check a couple of additional metrics – Jaccard and adjusted-cosine similarity – which weren't currently supported.

This pull request adds those metrics and updates the documentation to mention them.